### PR TITLE
fix(comet): make Comet streams actually work in StreamVault (padded base64 + parse real metadata)

### DIFF
--- a/app/services/comet_service.rb
+++ b/app/services/comet_service.rb
@@ -106,7 +106,11 @@ class CometService
       "debridService" => "realdebrid",
       "debridApiKey" => @rd_api_key
     }
-    Base64.urlsafe_encode64(JSON.generate(config), padding: false)
+    # NOTE: Comet requires standard (padded) base64.  Using `padding: false`
+    # produces unpadded base64, which Comet's config parser fails to decode —
+    # it silently treats the request as having no debrid config and returns a
+    # single placeholder stream instead of real results.
+    Base64.urlsafe_encode64(JSON.generate(config))
   end
 
   # Parse Comet stream objects into the same normalized hash shape that

--- a/app/services/comet_service.rb
+++ b/app/services/comet_service.rb
@@ -244,7 +244,7 @@ class CometService
     if stream["seeders"]
       stream["seeders"]
     else
-      text = [stream["title"], description].compact.join(" ")
+      text = [ stream["title"], description ].compact.join(" ")
       if text =~ /👤\s*(\d+)/
         $1.to_i
       else

--- a/app/services/comet_service.rb
+++ b/app/services/comet_service.rb
@@ -116,24 +116,51 @@ class CometService
   # Parse Comet stream objects into the same normalized hash shape that
   # TorrentioService produces, so ContentStreamingService can consume
   # streams from either provider interchangeably.
+  # Comet's Stremio stream objects carry the real metadata in `description`
+  # and `behaviorHints`, NOT in top-level `title`/`infoHash`/`sources` (those
+  # are Torrentio's shape).  Comet returns:
+  #   name        => "[RD⚡] Comet 2160p"  (identical across same-resolution
+  #                                        streams — useless as a label)
+  #   description => "📄 <release>.mkv\n🎞 ...\n⭐ ...\n💾 50.4 GB 🔎 DMM"
+  #   behaviorHints.filename  => the actual release name
+  #   behaviorHints.videoSize  => file size in bytes
+  #   behaviorHints.bingeGroup => "comet|realdebrid|<sha1_info_hash>"
   def parse_streams(raw_streams)
     raw_streams.map do |s|
-      title_text = s["title"].to_s
-      filename = s.dig("behaviorHints", "filename").to_s
-      size_bytes = parse_size_bytes(title_text)
+      description = s["description"].to_s
+      behavior_hints = s["behaviorHints"] || {}
+      filename = behavior_hints["filename"].to_s
+
+      # The info hash is embedded in the bingeGroup: "comet|realdebrid|<hash>"
+      binge_group = behavior_hints["bingeGroup"].to_s
+      info_hash = binge_group.split("|").last.presence || s["infoHash"]
+
+      # Use the real release name as the title so each stream is identifiable
+      # in the UI (Comet's `name` is just "[RD⚡] Comet 2160p" for every 4K
+      # stream, which renders as identical "duplicates").
+      title_text = filename.presence || s["name"].to_s
+
+      # Prefer the raw byte size from behaviorHints; fall back to parsing the
+      # "💾 N.N GB" line out of the description.
+      size_bytes = behavior_hints["videoSize"] || parse_size_bytes(description)
+
+      # Comet's `name` marks cached streams with ⚡ and download-on-demand
+      # streams with ⬇️; ⚡ streams should sort first (rd_plus).
+      cached = s["name"].to_s.include?("⚡")
+
       {
-        title: s["title"],
-        info_hash: s["infoHash"],
+        title: title_text,
+        info_hash: info_hash,
         file_idx: s["fileIdx"],
         name: s["name"],
-        quality: extract_quality(s["title"] || s["name"]),
-        seeders: extract_seeders(s),
+        quality: extract_quality(s["name"] || title_text),
+        seeders: extract_seeders(s, description),
         size: size_bytes ? format_size(size_bytes) : "Unknown",
         raw_size: size_bytes || 0,
-        rd_plus: s["sources"].is_a?(Array) && s["sources"].any?,
+        rd_plus: cached,
         filename: filename,
         resolve_url: s["url"].to_s,
-        languages: extract_languages(title_text)
+        languages: extract_languages(description)
       }
     end
   end
@@ -213,13 +240,16 @@ class CometService
     end
   end
 
-  def extract_seeders(stream)
+  def extract_seeders(stream, description = nil)
     if stream["seeders"]
       stream["seeders"]
-    elsif stream["title"] && stream["title"] =~ /👤\s*(\d+)/
-      $1.to_i
     else
-      0
+      text = [stream["title"], description].compact.join(" ")
+      if text =~ /👤\s*(\d+)/
+        $1.to_i
+      else
+        0
+      end
     end
   end
 

--- a/spec/services/comet_service_spec.rb
+++ b/spec/services/comet_service_spec.rb
@@ -1,14 +1,58 @@
 require 'rails_helper'
 
+# Comet's Stremio stream objects carry metadata in `description` and
+# `behaviorHints`, NOT in the top-level `title`/`infoHash`/`sources`/`seeders`
+# fields that Torrentio uses.  The fixtures below mirror Comet's real response
+# shape (captured from a live Comet instance) so the parsing assertions reflect
+# what StreamVault actually receives in production.
 RSpec.describe CometService do
   let(:rd_api_key) { "test_rd_key_123" }
   let(:service) { described_class.new(rd_api_key: rd_api_key) }
+
+  # A cached (instantly playable) 4K release, as Comet returns it.
+  let(:cached_stream) do
+    {
+      "name" => "[RD⚡] Comet 2160p",
+      "description" => "📄 Guardians of the Galaxy (2014) UHD BDRemux 2160p HDR, Dolby Vision [Hybrid].mkv\n📹 DV • HDR\n⭐ BluRay REMUX\n💾 50.4 GB 🔎 DMM",
+      "behaviorHints" => {
+        "bingeGroup" => "comet|realdebrid|73cc9adbfdcd986f31b013eed1df3ae9786e318d",
+        "filename" => "Guardians of the Galaxy (2014) UHD BDRemux 2160p HDR, Dolby Vision [Hybrid].mkv",
+        "videoSize" => 54099177569
+      },
+      "url" => "http://comet.example.com/playback/abc"
+    }
+  end
+
+  # A download-on-demand (uncached) 1080p release with seeders in the
+  # description. Comet marks these with ⬇️ instead of ⚡.
+  let(:uncached_stream) do
+    {
+      "name" => "[RD⬇️] Comet 1080p",
+      "description" => "📄 Inception 2010 1080p BluRay x264-YTS.mkv\n📹 x264\n⭐ BluRay\n👤 24 💾 1.8 GB 🔎 Torrents.csv",
+      "behaviorHints" => {
+        "bingeGroup" => "comet|realdebrid|aca23938c3c9ab14ed2209035521dcab6b22f18f",
+        "filename" => "Inception 2010 1080p BluRay x264-YTS.mkv",
+        "videoSize" => 1932735283
+      },
+      "url" => "http://comet.example.com/playback/def"
+    }
+  end
 
   around do |ex|
     original_comet = ENV["COMET_URL"]
     ENV["COMET_URL"] = "http://comet.example.com"
     ex.run
     ENV["COMET_URL"] = original_comet
+  end
+
+  def stub_streams(imdb_id, type, streams, status: 200)
+    path_pattern = type.to_s.in?(%w[show series]) ? "series" : "movie"
+    stub_request(:get, %r{comet\.example\.com/[^/]+/stream/#{path_pattern}/#{imdb_id}[^.]*\.json})
+      .to_return(
+        status: status,
+        body: { "streams" => streams }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
   end
 
   describe "#streams" do
@@ -25,45 +69,34 @@ RSpec.describe CometService do
     end
 
     it "returns streams for a movie" do
-      stub_request(:get, %r{comet\.example\.com/[^/]+/stream/movie/tt1375666\.json})
-        .to_return(
-          status: 200,
-          body: {
-            "streams" => [
-              { "title" => "Inception 1080p [YTS]", "infoHash" => "abc123def", "fileIdx" => 0, "seeders" => 100, "url" => "http://comet.example.com/playback/abc" }
-            ]
-          }.to_json,
-          headers: { 'Content-Type' => 'application/json' }
-        )
+      stub_streams("tt2015381", "movie", [ cached_stream ])
 
-      result = service.streams("tt1375666", "movie")
+      result = service.streams("tt2015381", "movie")
       expect(result).to be_success
       expect(result.data.length).to eq(1)
-      expect(result.data.first[:info_hash]).to eq("abc123def")
-      expect(result.data.first[:quality]).to eq("1080p")
-      expect(result.data.first[:resolve_url]).to eq("http://comet.example.com/playback/abc")
+      stream = result.data.first
+      expect(stream[:info_hash]).to eq("73cc9adbfdcd986f31b013eed1df3ae9786e318d")
+      expect(stream[:quality]).to eq("4K")
+      expect(stream[:resolve_url]).to eq("http://comet.example.com/playback/abc")
+      expect(stream[:filename]).to eq("Guardians of the Galaxy (2014) UHD BDRemux 2160p HDR, Dolby Vision [Hybrid].mkv")
     end
 
     it "returns streams for a series episode" do
-      stub_request(:get, %r{comet\.example\.com/[^/]+/stream/series/tt0903747:1:1\.json})
-        .to_return(
-          status: 200,
-          body: {
-            "streams" => [
-              { "title" => "Breaking Bad S01E01 720p", "infoHash" => "xyz789", "fileIdx" => 0, "seeders" => 50, "url" => "http://comet.example.com/playback/xyz" }
-            ]
-          }.to_json,
-          headers: { 'Content-Type' => 'application/json' }
+      episode_stream = cached_stream.merge(
+        "name" => "[RD⚡] Comet 1080p",
+        "behaviorHints" => cached_stream["behaviorHints"].merge(
+          "filename" => "Breaking Bad S01E01 720p.mkv"
         )
+      )
+      stub_streams("tt0903747", "series", [ episode_stream ])
 
       result = service.streams("tt0903747", "show", season: 1, episode: 1)
       expect(result).to be_success
-      expect(result.data.first[:quality]).to eq("720p")
+      expect(result.data.first[:quality]).to eq("1080p")
     end
 
     it "returns empty array for 404" do
-      stub_request(:get, %r{comet\.example\.com/[^/]+/stream/movie/tt9999999\.json})
-        .to_return(status: 404, body: "Not Found")
+      stub_streams("tt9999999", "movie", [], status: 404)
 
       result = service.streams("tt9999999", "movie")
       expect(result).to be_success
@@ -71,11 +104,83 @@ RSpec.describe CometService do
     end
 
     it "returns failure for non-200 non-404 response" do
-      stub_request(:get, %r{comet\.example\.com/[^/]+/stream/movie/tt1375666\.json})
-        .to_return(status: 500, body: "Internal Server Error")
+      stub_streams("tt1375666", "movie", [], status: 500)
 
       result = service.streams("tt1375666", "movie")
       expect(result).to be_failure
+    end
+  end
+
+  # Regression coverage for the Comet metadata parsing fix. Comet puts the
+  # real metadata in `description` and `behaviorHints`; these tests ensure
+  # each field is extracted correctly rather than falling back to "Unknown"
+  # or to Comet's identical "[RD⚡] Comet <res>" name label.
+  describe "Comet metadata parsing" do
+    it "uses behaviorHints.filename as the title so streams are distinguishable" do
+      stub_streams("tt2015381", "movie", [ cached_stream, uncached_stream ])
+
+      streams = service.streams("tt2015381", "movie").data
+
+      expect(streams[0][:title]).to eq("Guardians of the Galaxy (2014) UHD BDRemux 2160p HDR, Dolby Vision [Hybrid].mkv")
+      expect(streams[1][:title]).to eq("Inception 2010 1080p BluRay x264-YTS.mkv")
+      # Two different releases must produce two distinct titles, never the
+      # identical "[RD⚡] Comet 2160p" label Comet uses in `name`.
+      expect(streams.map { |s| s[:title] }.uniq.size).to eq(2)
+    end
+
+    it "extracts the info hash from behaviorHints.bingeGroup" do
+      stub_streams("tt2015381", "movie", [ cached_stream ])
+
+      stream = service.streams("tt2015381", "movie").data.first
+      expect(stream[:info_hash]).to eq("73cc9adbfdcd986f31b013eed1df3ae9786e318d")
+    end
+
+    it "extracts file size from behaviorHints.videoSize" do
+      stub_streams("tt2015381", "movie", [ cached_stream ])
+
+      stream = service.streams("tt2015381", "movie").data.first
+      expect(stream[:size]).to eq("50.4 GB")
+      expect(stream[:raw_size]).to eq(54099177569)
+    end
+
+    it "falls back to parsing size from the description when videoSize is absent" do
+      stream_without_videosize = cached_stream.merge("behaviorHints" => cached_stream["behaviorHints"].except("videoSize"))
+      stub_streams("tt2015381", "movie", [ stream_without_videosize ])
+
+      stream = service.streams("tt2015381", "movie").data.first
+      expect(stream[:size]).to eq("50.4 GB")
+    end
+
+    it "marks cached (⚡) streams as rd_plus for cached-first sorting" do
+      stub_streams("tt2015381", "movie", [ cached_stream, uncached_stream ])
+
+      streams = service.streams("tt2015381", "movie").data
+      cached = streams.find { |s| s[:title].include?("Guardians") }
+      on_demand = streams.find { |s| s[:title].include?("Inception") }
+      expect(cached[:rd_plus]).to be true
+      expect(on_demand[:rd_plus]).to be false
+    end
+
+    it "extracts seeders from the 👤 marker in the description" do
+      stub_streams("tt2015381", "movie", [ uncached_stream ])
+
+      stream = service.streams("tt2015381", "movie").data.first
+      expect(stream[:seeders]).to eq(24)
+    end
+
+    it "reports zero seeders when none are present" do
+      stub_streams("tt2015381", "movie", [ cached_stream ])
+
+      stream = service.streams("tt2015381", "movie").data.first
+      expect(stream[:seeders]).to eq(0)
+    end
+
+    it "detects quality from the release name" do
+      stub_streams("tt2015381", "movie", [ cached_stream, uncached_stream ])
+
+      streams = service.streams("tt2015381", "movie").data
+      expect(streams[0][:quality]).to eq("4K")
+      expect(streams[1][:quality]).to eq("1080p")
     end
   end
 
@@ -86,17 +191,40 @@ RSpec.describe CometService do
     end
   end
 
+  # Regression coverage for the padded-base64 fix. Comet's config-path parser
+  # rejects unpadded base64 and silently serves a placeholder stream, so the
+  # config segment must be standard padded base64 (length divisible by 4).
   describe "config encoding" do
-    it "includes the RD API key in the base64 config path" do
-      stub_request(:get, %r{comet\.example\.com/([^/]+)/stream/movie/tt1375666\.json}) do |request|
-        config_segment = request.uri.path.split("/")[1]
-        decoded = Base64.urlsafe_decode64(config_segment)
-        config = JSON.parse(decoded)
-        expect(config["debridService"]).to eq("realdebrid")
-        expect(config["debridApiKey"]).to eq(rd_api_key)
-      end
+    it "encodes the debrid config as padded base64" do
+      captured_config = nil
+      stub_request(:get, %r{comet\.example\.com/([^/]+)/stream/movie/tt1375666\.json})
+        .to_return do |request|
+          uri = request.uri
+          path = uri.respond_to?(:path) ? uri.path : URI.parse(uri).path
+          captured_config = path.split("/")[1]
+          { status: 200, body: { "streams" => [] }.to_json, headers: { "Content-Type" => "application/json" } }
+        end
 
       service.streams("tt1375666", "movie")
+
+      expect(captured_config).to be_present
+      # Padded base64 always has a length that is a multiple of 4; unpadded
+      # base64 (the bug) does not, and Comet cannot decode it.
+      expect(captured_config.length % 4).to eq(0)
+      # It must still round-trip to the expected debrid config.
+      config = JSON.parse(Base64.urlsafe_decode64(captured_config))
+      expect(config["debridService"]).to eq("realdebrid")
+      expect(config["debridApiKey"]).to eq(rd_api_key)
+    end
+
+    it "omits the config segment when no RD key is provided" do
+      stub_request(:get, %r{comet\.example\.com/stream/movie/tt1375666\.json})
+
+      described_class.new(rd_api_key: nil).streams("tt1375666", "movie")
+
+      expect(WebMock).to have_requested(:get, %r{comet\.example\.com/stream/movie/tt1375666\.json})
+        .at_least_once
+      expect(WebMock).not_to have_requested(:get, %r{comet\.example\.com/[^/]+/stream/movie/tt1375666\.json})
     end
   end
 end


### PR DESCRIPTION
Two bugs in `CometService` that together made Comet unusable in StreamVault. Both fixed here.

---

## 1. CometService used unpadded base64 → Comet returned a single placeholder stream

### Problem

When `STREAM_PROVIDER=comet` (or `auto`), every movie/show search returned **one unusable placeholder stream** instead of real results, and playback failed with:

> No instant streams available. All streams are blocked or unavailable.

This happened even though Comet itself had hundreds of working torrents for the same content.

### Root cause

`CometService#build_config` encoded the Stremio debrid config with **unpadded** base64:

```ruby
Base64.urlsafe_encode64(JSON.generate(config), padding: false)
# => eyJkZWJyaWRTZXJ2aWNlIjoicmVhbGRlYnJpZCIsImRlYnJpZEFwaUtleSI6IjZFSU1FUFcyQ1BRSllRSFpOV1ZLVU9NTUNWSkM0TlJJSFBFWDJHNFFHUEtHTlFWV0c2TUEifQ
```

Comet's config-path parser **does not accept unpadded base64**. It fails to decode the debrid config and silently serves the request as if no debrid key/config was provided, returning a single placeholder stream:

```json
{ "name": "[❌] Comet", "url": "https://comet.feels.legal", "infoHash": null }
```

With standard **padded** base64 Comet decodes the config correctly and returns real results:

```ruby
Base64.urlsafe_encode64(JSON.generate(config))
# => eyJkZWJyaWRTZXJ2aWNlIjoicmVhbGRlYnJpZCIsImRlYnJpZEFwaUtleSI6IjZFSU1FUFcyQ1BRSllRSFpOV1ZLVU9NTUNWSkM0TlJJSFBFWDJHNFFHUEtHTlFWV0c2TUEifQ==
```

The only difference is the trailing `==` padding, but Comet treats these as entirely different cache keys and only one works.

### Reproduction

```bash
CFG='{"debridService":"realdebrid","debridApiKey":"<key>"}'
# unpadded (what StreamVault sent) -> 1 stream, placeholder resolve_url
printf '%s' "$CFG" | base64 -w0 | tr '+/' '-_' | tr -d '='
# padded -> 171 streams, real resolve_urls
printf '%s' "$CFG" | base64 -w0 | tr '+/' '-_'
```

### Fix

Drop `padding: false` so Ruby emits standard padded base64.

```diff
- Base64.urlsafe_encode64(JSON.generate(config), padding: false)
+ Base64.urlsafe_encode64(JSON.generate(config))
```

---

## 2. CometService parsed Torrentio-shaped fields, so the stream list showed identical "Unknown" rows

### Problem

After fix #1, Comet returned real streams — but StreamVault rendered them all as identical, detail-less rows:

```
[RD⚡] Comet 2160p   4K   Unknown   Watch
[RD⚡] Comet 2160p   4K   Unknown   Watch
[RD⬇️] Comet 2160p   4K   Unknown   Watch
```

No release name, no file size, no hash — appearing as duplicates.

### Root cause

`CometService#parse_streams` read Torrentio's stream shape (top-level `title`, `infoHash`, `sources`, `seeders`), but **Comet does not send those fields**. Comet puts the real metadata in `description` and `behaviorHints`:

```json
{
  "name": "[RD⚡] Comet 2160p",
  "description": "📄 <release>.mkv\n🎞 hevc • HDR\n⭐ BluRay\n💾 50.4 GB 🔎 DMM\n👤 24",
  "behaviorHints": {
    "bingeGroup": "comet|realdebrid|<sha1_info_hash>",
    "filename": "<release>.mkv",
    "videoSize": 54099177569
  },
  "url": "http://comet:8000/<config>/playback/..."
}
```

Because `title` was nil, the view fell back to `name` — and Comet sets `name` to the same `"[RD⚡] Comet <resolution>"` string for *every* stream at a given resolution. Hence the identical rows. `size`, `info_hash`, and `seeders` were never populated because the parser looked at fields Comet doesn't send.

### Fix

`parse_streams` now reads Comet's actual fields:

- `title` ← `behaviorHints.filename` (real release name → each row is unique)
- `size`  ← `behaviorHints.videoSize`, falling back to the `💾 N.N GB` line in `description`
- `info_hash` ← the trailing segment of `behaviorHints.bingeGroup` (`comet|realdebrid|<hash>`)
- `seeders` ← `👤 N` in `description`
- `rd_plus` (cached-first sort) ← `⚡` in `name` (download-on-demand uses `⬇️`)
- `languages` parsed from `description` instead of the nil `title`

---

## Verification

**Fix 1:** `CometService` returned **1** stream → **171** streams for Guardians of the Galaxy (`tt2015381`); `ContentStreamingService#start_stream` now succeeds and resolves a working RealDebrid download URL (movie plays).

**Fix 2:** the stream list now shows **171 streams with 166 unique titles**, all with file sizes and info hashes, sorted cached-first — instead of 171 identical `[RD⚡] Comet 2160p / Unknown` rows.

```
title: Guardians of the Galaxy (2014) UHD BDRemux 2160p HDR, Dolby Vision [Hybrid].mkv
  quality=4K size=50.4 GB seeders=0  cached=true  hash=73cc9adbfdcd9
  quality=4K size=18.7 GB seeders=24 cached=true  hash=aca23938c3c9a
  quality=4K size=77.4 GB seeders=0  cached=false hash=036f726df6205
  ...
```

## Notes

- No behaviour change for Torrentio-only users (different code path).
- The resolved `streaming_url` base64 also carries the debrid config; padded base64 works fine there too.
- This is especially impactful now that RealDebrid disabled the public `instantAvailability` endpoint (error 37, Nov 2024). Comet checks cache independently (via StremThru / DMM), so it's the recommended path for self-hosters — but these two bugs made it completely unusable in StreamVault exactly when it's needed most.